### PR TITLE
fix incorrect target path when only uploading one partition

### DIFF
--- a/controller/src/test/java/com/pinterest/terrapin/controller/ControllerUtilTest.java
+++ b/controller/src/test/java/com/pinterest/terrapin/controller/ControllerUtilTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.pinterest.terrapin.Constants;
+import com.pinterest.terrapin.TerrapinUtil;
 import com.pinterest.terrapin.thrift.generated.PartitionerType;
 
 import com.google.common.collect.Sets;
@@ -56,7 +57,7 @@ public class ControllerUtilTest {
     HdfsFileStatus[] fileStatuses = new HdfsFileStatus[numPartitions];
     for (int i = 0; i < numPartitions; ++i) {
       fileStatuses[i] = PowerMockito.mock(HdfsFileStatus.class);
-      String localName = String.format("part-%05d", i);
+      String localName = TerrapinUtil.formatPartitionName(i);
       when(fileStatuses[i].getLocalName()).thenReturn(localName);
       when(fileStatuses[i].getFullName(eq(hdfsDir))).thenReturn(hdfsDir + "/" + localName);
       when(fileStatuses[i].getLen()).thenReturn(1000L);

--- a/controller/src/test/java/com/pinterest/terrapin/controller/HdfsManagerTest.java
+++ b/controller/src/test/java/com/pinterest/terrapin/controller/HdfsManagerTest.java
@@ -259,7 +259,7 @@ public class HdfsManagerTest {
       for (int j = 1 ; j <= partitions; ++j) {
         resourceFsStatusList[j] = buildHdfsStatus(
                 TerrapinUtil.helixResourceToHdfsDir(resource) +
-            String.format("/part-%05d", j - 1), false, null);
+            String.format("/%s", TerrapinUtil.formatPartitionName(j - 1)), false, null);
       }
       when(mockDfsClient.listPaths(eq(TerrapinUtil.helixResourceToHdfsDir(resource)),
           any(byte[].class))). thenReturn(new DirectoryListing(resourceFsStatusList, 0));
@@ -272,7 +272,7 @@ public class HdfsManagerTest {
       throws IOException {
     for (Map.Entry<Integer, List<String>> entry : locationMap.entrySet()) {
       String path = TerrapinUtil.helixResourceToHdfsDir(resource) +
-          String.format("/part-%05d", entry.getKey());
+          String.format("/%s", TerrapinUtil.formatPartitionName(entry.getKey()));
       BlockLocation[] locations = new BlockLocation[1];
       String[] hostsArray = new String[entry.getValue().size()];
       entry.getValue().toArray(hostsArray);
@@ -338,14 +338,16 @@ public class HdfsManagerTest {
 
   private void checkHdfsBlocksNotRetrieved(String resource, int numPartitions) throws Exception {
     for (int i = 0; i < numPartitions; ++i) {
-      String path = TerrapinUtil.helixResourceToHdfsDir(resource) + String.format("/part-%05d", i);
+      String path = TerrapinUtil.helixResourceToHdfsDir(resource) +
+          String.format("/%s", TerrapinUtil.formatPartitionName(i));
       verify(mockDfsClient, times(0)).getBlockLocations(eq(path), eq(0L), anyLong());
     }
   }
 
   private void checkHdfsBlocksRetrieved(String resource, int numPartitions) throws Exception {
     for (int i = 0; i < numPartitions; ++i) {
-      String path = TerrapinUtil.helixResourceToHdfsDir(resource) + String.format("/part-%05d", i);
+      String path = TerrapinUtil.helixResourceToHdfsDir(resource) +
+          String.format("/%s", TerrapinUtil.formatPartitionName(i));
       verify(mockDfsClient, times(1)).getBlockLocations(eq(path), eq(0L), anyLong());
     }
   }

--- a/core/src/main/java/com/pinterest/terrapin/TerrapinUtil.java
+++ b/core/src/main/java/com/pinterest/terrapin/TerrapinUtil.java
@@ -122,6 +122,10 @@ public class TerrapinUtil {
     return null;
   }
 
+  public static String formatPartitionName(int partitionNumber) {
+    return String.format("%s%05d", Constants.FILE_PREFIX, partitionNumber);
+  }
+
   public static String getPartitionName(ByteBuffer key,
                                         PartitionerType partitionerType,
                                         int numPartitions) {

--- a/core/src/main/java/com/pinterest/terrapin/tools/HFileGenerator.java
+++ b/core/src/main/java/com/pinterest/terrapin/tools/HFileGenerator.java
@@ -19,6 +19,7 @@ package com.pinterest.terrapin.tools;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.pinterest.terrapin.PartitionerFactory;
+import com.pinterest.terrapin.TerrapinUtil;
 import com.pinterest.terrapin.thrift.generated.PartitionerType;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
@@ -143,7 +144,8 @@ public class HFileGenerator {
     StoreFile.Writer[] writers = new StoreFile.Writer[numOfPartitions];
     for (int i = 0; i < numOfPartitions; i++) {
       writers[i] = new StoreFile.WriterBuilder(conf, new CacheConfig(conf), sourceFileSystem, 4096)
-          .withFilePath(new Path(String.format("%s/part-%05d", outputFolder.getAbsoluteFile(), i)))
+          .withFilePath(new Path(String.format("%s/%s", outputFolder.getAbsoluteFile(),
+              TerrapinUtil.formatPartitionName(i))))
           .withCompression(Compression.Algorithm.NONE)
           .build();
     }

--- a/core/src/test/java/com/pinterest/terrapin/TerrapinUtilTest.java
+++ b/core/src/test/java/com/pinterest/terrapin/TerrapinUtilTest.java
@@ -71,16 +71,25 @@ public class TerrapinUtilTest {
   @Test
   public void testExtractPartitionName() {
     assertEquals(new Integer(10), TerrapinUtil.extractPartitionName(
-        "part-00010-ad2", PartitionerType.MODULUS));
+        Constants.FILE_PREFIX + "00010-ad2", PartitionerType.MODULUS));
     assertEquals(new Integer(10), TerrapinUtil.extractPartitionName(
-        "part-00010", PartitionerType.MODULUS));
-    Assert.assertNull(TerrapinUtil.extractPartitionName("part-929-ad2", PartitionerType.MODULUS));
+        Constants.FILE_PREFIX + "00010", PartitionerType.MODULUS));
+    Assert.assertNull(TerrapinUtil.extractPartitionName(Constants.FILE_PREFIX + "929-ad2",
+        PartitionerType.MODULUS));
 
     assertEquals(new Integer(10), TerrapinUtil.extractPartitionName(
-        "part-00010-ad2", PartitionerType.CASCADING));
+        Constants.FILE_PREFIX + "00010-ad2", PartitionerType.CASCADING));
     assertEquals(new Integer(10), TerrapinUtil.extractPartitionName(
-        "part-00010", PartitionerType.CASCADING));
-    Assert.assertNull(TerrapinUtil.extractPartitionName("part-929-ad2", PartitionerType.CASCADING));
+        Constants.FILE_PREFIX + "00010", PartitionerType.CASCADING));
+    Assert.assertNull(TerrapinUtil.extractPartitionName(Constants.FILE_PREFIX + "929-ad2",
+        PartitionerType.CASCADING));
+  }
+
+  @Test
+  public void testFormatPartitionName() {
+    assertEquals(Constants.FILE_PREFIX + "00000", TerrapinUtil.formatPartitionName(0));
+    assertEquals(Constants.FILE_PREFIX + "00010", TerrapinUtil.formatPartitionName(10));
+    assertEquals(Constants.FILE_PREFIX + "99999", TerrapinUtil.formatPartitionName(99999));
   }
 
   @Test
@@ -112,9 +121,9 @@ public class TerrapinUtilTest {
   @Test
   public void testExtractFileSetFromResource() {
     assertEquals("file_set", TerrapinUtil.extractFileSetFromPath(
-        "/terrapin/data/file_set/1343443323/part-00000"));
+        "/terrapin/data/file_set/1343443323/" + TerrapinUtil.formatPartitionName(0)));
     assertEquals("file_set", TerrapinUtil.extractFileSetFromPath(
-        "/file_set/1343443323/part-00000"));
+        "/file_set/1343443323/" + TerrapinUtil.formatPartitionName(0)));
     Assert.assertNull(TerrapinUtil.extractFileSetFromPath("/file_set/1343443323"));
     Assert.assertNull(TerrapinUtil.extractFileSetFromPath("/file_set"));
     Assert.assertNull(TerrapinUtil.extractFileSetFromPath("/file_set"));

--- a/core/src/test/java/com/pinterest/terrapin/storage/HFileReaderTest.java
+++ b/core/src/test/java/com/pinterest/terrapin/storage/HFileReaderTest.java
@@ -49,6 +49,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.pinterest.terrapin.TerrapinUtil;
+
 /**
  * Unit test for HFileReader. The test creates an HFile with upto 10K keys on the local file system.
  * It then instantiates an HFileReader over the local file system to issue HFile lookups and
@@ -200,7 +202,8 @@ public class HFileReaderTest {
 
   @Test
   public void testTerrapinPath() {
-    Path path = new HFileReader.TerrapinPath("/terrapin/data/meta_user_join/1234/part-00000");
-    assertEquals("part-00000_meta_user_join_1234", path.getName());
+    String partName = TerrapinUtil.formatPartitionName(0);
+    Path path = new HFileReader.TerrapinPath("/terrapin/data/meta_user_join/1234/" + partName);
+    assertEquals(partName + "_meta_user_join_1234", path.getName());
   }
 }

--- a/core/src/test/java/com/pinterest/terrapin/tools/HFileGeneratorTest.java
+++ b/core/src/test/java/com/pinterest/terrapin/tools/HFileGeneratorTest.java
@@ -18,6 +18,7 @@ package com.pinterest.terrapin.tools;
 
 import static org.junit.Assert.assertEquals;
 
+import com.pinterest.terrapin.Constants;
 import com.pinterest.terrapin.thrift.generated.PartitionerType;
 
 import com.google.common.io.Files;
@@ -55,7 +56,7 @@ public class HFileGeneratorTest {
     FilenameFilter hfileFilter = new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
-        return name.startsWith("part-");
+        return name.startsWith(Constants.FILE_PREFIX);
       }
     };
     File[] hfiles = outputDir.listFiles(hfileFilter);

--- a/hadoop2/src/main/java/com/pinterest/terrapin/hadoop/BaseUploader.java
+++ b/hadoop2/src/main/java/com/pinterest/terrapin/hadoop/BaseUploader.java
@@ -203,6 +203,9 @@ public abstract class BaseUploader {
       for (Pair<Path, Long> fileSize : fileSizePairList) {
         sourceFiles.add(fileSize.getLeft());
       }
+      if (sourceFiles.size() == 1) {
+        hdfsDir = hdfsDir + "/" + TerrapinUtil.formatPartitionName(0);
+      }
       DistCpOptions distCpOptions = new DistCpOptions(sourceFiles,
           new Path("hdfs", terrapinNamenode, hdfsDir));
       distCpOptions.setSyncFolder(true);

--- a/hadoop2/src/main/java/com/pinterest/terrapin/hadoop/HFileOutputFormat.java
+++ b/hadoop2/src/main/java/com/pinterest/terrapin/hadoop/HFileOutputFormat.java
@@ -17,6 +17,8 @@
 package com.pinterest.terrapin.hadoop;
 
 import com.pinterest.terrapin.Constants;
+import com.pinterest.terrapin.TerrapinUtil;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -64,7 +66,7 @@ public class HFileOutputFormat extends FileOutputFormat<BytesWritable, BytesWrit
    * @return Full HFile path
    */
   public static Path hfilePath(Path outputPath, int partitionIndex) {
-    return new Path(outputPath, String.format("part-%05d", partitionIndex));
+    return new Path(outputPath, TerrapinUtil.formatPartitionName(partitionIndex));
   }
 
   public RecordWriter<BytesWritable, BytesWritable> getRecordWriter(

--- a/hadoop2/src/test/java/com/pinterest/terrapin/hadoop/HFileOutputFormatTest.java
+++ b/hadoop2/src/test/java/com/pinterest/terrapin/hadoop/HFileOutputFormatTest.java
@@ -18,6 +18,8 @@ package com.pinterest.terrapin.hadoop;
 
 import static org.junit.Assert.assertEquals;
 
+import com.pinterest.terrapin.TerrapinUtil;
+
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.Compression;
 import org.junit.Test;
@@ -36,7 +38,7 @@ public class HFileOutputFormatTest {
   public void testHFilePath() {
     Path outputDir = new Path("/abc/def");
     int partitionIndex = 233;
-    Path expectedDir = new Path("/abc/def/part-00233");
+    Path expectedDir = new Path("/abc/def/" + TerrapinUtil.formatPartitionName(233));
     assertEquals(expectedDir, HFileOutputFormat.hfilePath(outputDir, partitionIndex));
   }
 }

--- a/server/src/main/java/com/pinterest/terrapin/server/OnlineOfflineStateModelFactory.java
+++ b/server/src/main/java/com/pinterest/terrapin/server/OnlineOfflineStateModelFactory.java
@@ -74,8 +74,7 @@ public class OnlineOfflineStateModelFactory extends StateModelFactory<StateModel
     // strip out the resource from partition name.
     String partitionNum = message.getPartitionName().substring(
         message.getResourceName().length() + 1);
-    String partitionName = "part-" + String.format("%05d",
-        Integer.parseInt(partitionNum));
+    String partitionName = TerrapinUtil.formatPartitionName(Integer.parseInt(partitionNum));
     String hdfsPath = TerrapinUtil.helixResourceToHdfsDir(message.getResourceName()) +
         "/" + partitionName;
 

--- a/server/src/test/java/com/pinterest/terrapin/server/OnlineOfflineStateModelFactoryTest.java
+++ b/server/src/test/java/com/pinterest/terrapin/server/OnlineOfflineStateModelFactoryTest.java
@@ -16,6 +16,7 @@
 */
 package com.pinterest.terrapin.server;
 
+import com.pinterest.terrapin.TerrapinUtil;
 import com.pinterest.terrapin.storage.Reader;
 import com.pinterest.terrapin.storage.ReaderFactory;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -67,7 +68,8 @@ public class OnlineOfflineStateModelFactoryTest {
     this.stateModel.onBecomeOnlineFromOffline(mockHelixMessage, null);
     verify(mockResourcePartitionMap).addReader(
         eq("$terrapin$data$file_set$1393"), eq("100"), Matchers.<Reader>anyObject());
-    verify(mockReaderFactory).createHFileReader(eq("/terrapin/data/file_set/1393/part-00100"),
+    verify(mockReaderFactory).createHFileReader(eq("/terrapin/data/file_set/1393/" +
+            TerrapinUtil.formatPartitionName(100)),
         Matchers.<CacheConfig>anyObject());
   }
 
@@ -79,7 +81,8 @@ public class OnlineOfflineStateModelFactoryTest {
     this.stateModel.onBecomeOnlineFromOffline(mockHelixMessage, null);
     verify(mockResourcePartitionMap).addReader(
         eq("$terrapin$data$file_set$1393"), eq("100"), Matchers.<Reader>anyObject());
-    verify(mockReaderFactory).createHFileReader(eq("/terrapin/data/file_set/1393/part-00100"),
+    verify(mockReaderFactory).createHFileReader(eq("/terrapin/data/file_set/1393/" +
+        TerrapinUtil.formatPartitionName(100)),
         Matchers.<CacheConfig>anyObject());
   }
 


### PR DESCRIPTION
This bug is caused by ambiguity of DistCP's input parameters for Hadoop 2.0.0. If there are more than one files to be uploaded, the target path is treated as directory. However, if there is only one file to be uploaded, the target path is treated as a regular file. So in our code, we need to get rid of this ambiguity by using full partition path(not its parent directory) as target path when only one partition is loading.

This PR also add `TerrapinUtil.formatPartitionName` to format partition name, instead of hard coded `"part-%05d"`.

@varunsharmagit 
